### PR TITLE
Removing unnecessary libraries

### DIFF
--- a/BrowserStackLocal/BrowserStackLocal/BrowserStackLocal.csproj
+++ b/BrowserStackLocal/BrowserStackLocal/BrowserStackLocal.csproj
@@ -40,26 +40,6 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net20\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.1\lib\net20\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/BrowserStackLocal/BrowserStackLocal/packages.config
+++ b/BrowserStackLocal/BrowserStackLocal/packages.config
@@ -2,6 +2,4 @@
 <packages>
   <package id="log4net" version="2.0.5" targetFramework="net20" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net20" />
-  <package id="NUnit" version="3.2.1" targetFramework="net20" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net20" />
 </packages>


### PR DESCRIPTION
Nunit framework and NunitTestAdapter is absolutely not necessary in the BrowserStackLocal library since they can be added in test project. Having Nunit 3 in the library forces everybody to use this 3rd version of NUnit which might cause problems when using earlier version of ReScharper like 9.1.
