### PR TITLE
CI/CD: install .NET 6 (matches binding TFM after LOC-6563)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.410
+        dotnet-version: 6.0.x
     - name: Run Integration Tests
       env:
         BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.410
+        dotnet-version: 6.0.x
     - name: Run Integration Tests
       env:
         BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}


### PR DESCRIPTION
## Summary

Post-merge hotfix for [LOC-6563](https://browserstack.atlassian.net/browse/LOC-6563). PR #57 dropped the binding's `<TargetFramework>` from `net7.0` to `net6.0` (commit `d968e36`) so the SDK could keep its .NET 6 consumers. The GitHub Actions workflows still install `dotnet-version: 7.0.410`, so `dotnet test BrowserStackLocalIntegrationTests` fails to launch — the test DLL is now `net6.0` and the runner only has 7.0.20 / 8.0.x / 9.0.x / 10.0.8 installed.

## Failure observed in CI

```
Testhost process for source(s) '...\BrowserStackLocalIntegrationTests.dll' exited with error:
  You must install or update .NET to run this application.
  Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
  The following frameworks were found:
    7.0.20, 8.0.6, 8.0.22, 8.0.27, 9.0.6, 9.0.16, 10.0.8
```

## Fix

Bump `actions/setup-dotnet@v3` install version from `7.0.410` → `6.0.x` in both `ci.yml` and `cd.yml`. msbuild steps still use the runner's pre-installed Visual Studio / SDK 10.x, unaffected.

## Test plan

- [ ] Merge → re-run the failed CD action → `dotnet test BrowserStackLocalIntegrationTests` should now find the 6.0 runtime and proceed to launch the testhost
- [ ] CI workflow on a follow-up PR should also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LOC-6563]: https://browserstack.atlassian.net/browse/LOC-6563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ