### PR TITLE
LOC-6727: validate source URL host before binary download

### DIFF
--- a/BrowserStackLocal/BrowserStackLocal/BrowserStackTunnel.cs
+++ b/BrowserStackLocal/BrowserStackLocal/BrowserStackTunnel.cs
@@ -237,6 +237,11 @@ namespace BrowserStack
       }
     }
 
+    // Each guard below covers a case the final host-equals check does not:
+    //   - null/empty URL: skip a parse attempt and give a clear error.
+    //   - Uri.TryCreate failure: malformed URL surfaces our own exception instead of leaving parsed null.
+    //   - HTTPS check: allowlist matches host only; without this, http://browserstack.com would pass.
+    //   - null/empty host: parsed.Host can be empty for some URL forms; give a clear error before reaching the allowlist loop.
     private static string ValidateSourceUrl(string url)
     {
       if (string.IsNullOrEmpty(url))

--- a/BrowserStackLocal/BrowserStackLocal/BrowserStackTunnel.cs
+++ b/BrowserStackLocal/BrowserStackLocal/BrowserStackTunnel.cs
@@ -21,6 +21,9 @@ namespace BrowserStack
 
   public class BrowserStackTunnel : IDisposable
   {
+    private static readonly string[] AllowedDownloadHosts = new string[] { "browserstack.com" };
+    private static readonly string[] AllowedDownloadHostSuffixes = new string[] { ".browserstack.com" };
+
     static readonly string uname = Util.GetUName();
     static readonly string binaryName = GetBinaryName();
 
@@ -229,9 +232,41 @@ namespace BrowserStack
           throw new Exception((string)jsonResponse["error"]);
         }
         
-        sourceUrl = jsonResponse["data"]?["endpoint"]?.ToString();
+        sourceUrl = ValidateSourceUrl(jsonResponse["data"]?["endpoint"]?.ToString());
         return sourceUrl;
       }
+    }
+
+    private static string ValidateSourceUrl(string url)
+    {
+      if (string.IsNullOrEmpty(url))
+      {
+        throw new Exception("Refusing binary download: empty source URL");
+      }
+      Uri parsed;
+      if (!Uri.TryCreate(url, UriKind.Absolute, out parsed))
+      {
+        throw new Exception("Refusing binary download: malformed source URL");
+      }
+      if (!string.Equals(parsed.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+      {
+        throw new Exception("Refusing binary download from non-HTTPS source URL");
+      }
+      string host = parsed.Host;
+      if (string.IsNullOrEmpty(host))
+      {
+        throw new Exception("Refusing binary download: source URL has no host");
+      }
+      host = host.ToLowerInvariant();
+      foreach (var allowed in AllowedDownloadHosts)
+      {
+        if (host.Equals(allowed)) return url;
+      }
+      foreach (var suffix in AllowedDownloadHostSuffixes)
+      {
+        if (host.EndsWith(suffix)) return url;
+      }
+      throw new Exception("Refusing binary download: host '" + host + "' is not in the allowed host list");
     }
 
     public void downloadBinary()


### PR DESCRIPTION
## Summary
Mirror the host allowlist added in [browserstack-local-java#99](https://github.com/browserstack/browserstack-local-java/pull/99) and [browserstack-local-python#62](https://github.com/browserstack/browserstack-local-python/pull/62). The `endpoint` returned by the binary endpoint API is now validated before being used to download the binary:
- must be HTTPS
- host must be `browserstack.com` or a `*.browserstack.com` subdomain

## Test plan
- [ ] Unit test: existing tests still pass
- [ ] Manual: normal binary download still works (endpoint resolves under `*.browserstack.com`)
- [ ] Manual: confirm a synthetic non-allowlisted endpoint throws `Refusing binary download: host '...' is not in the allowed host list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)